### PR TITLE
[RedDwarf] feat: build Sentinel — a local dev environment health monitor CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# Sentinel
+
+Sentinel is a local developer environment health monitor CLI. Run `sentinel check` to audit configured repositories, services, and basic system drift, then persist a daily Markdown report to `~/.sentinel/report-YYYY-MM-DD.md`.
+
+## Installation
+
+```bash
+pnpm install
+pnpm build
+pnpm check
+```
+
+## Config schema
+
+Sentinel loads `~/.sentinel/config.json` on every invocation.
+
+```json
+{
+  "repos": ["/absolute/path/to/repo"],
+  "services": [{ "name": "Postgres", "host": "127.0.0.1", "port": 5432 }],
+  "diskPath": "/",
+  "thresholds": {
+    "diskWarningPercent": 80,
+    "branchStaleDays": 30
+  }
+}
+```
+
+Defaults:
+- `repos`: `[]`
+- `services`: `[]`
+- `diskPath`: `/`
+- `thresholds.diskWarningPercent`: `80`
+- `thresholds.branchStaleDays`: `30`
+
+## Output
+
+Terminal sections:
+- `Git`
+- `Services`
+- `System`
+- overall status line: `✓ All systems healthy`, `⚠ X warning(s) found`, or `✗ X error(s) found`
+
+Example report:
+
+```md
+# Sentinel Report
+
+- Overall: warn
+- Timestamp: 2026-04-07T18:40:00.000Z
+
+## Git
+- /repo/app: warn
+  - Working tree has uncommitted changes.
+
+## Services
+- Postgres: up (12ms)
+
+## System
+- Disk: ok at 62% (/)
+```

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,15 @@
+{
+  "repos": [
+    "/Users/example/projects/sentinel",
+    "/Users/example/projects/api"
+  ],
+  "services": [
+    { "name": "Postgres", "host": "127.0.0.1", "port": 5432 },
+    { "name": "Redis", "host": "127.0.0.1", "port": 6379 }
+  ],
+  "diskPath": "/",
+  "thresholds": {
+    "diskWarningPercent": 80,
+    "branchStaleDays": 30
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "sentinel",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "sentinel": "./dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "check": "tsx src/cli.ts check",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^24.5.2",
+    "tsx": "^4.19.4",
+    "typescript": "^5.9.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1219 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^24.5.2
+        version: 24.12.2
+      tsx:
+        specifier: ^4.19.4
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@24.12.2)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.60.1:
+    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@24.12.2))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@24.12.2)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.60.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.1
+      '@rollup/rollup-android-arm64': 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-darwin-x64': 4.60.1
+      '@rollup/rollup-freebsd-arm64': 4.60.1
+      '@rollup/rollup-freebsd-x64': 4.60.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-loong64-gnu': 4.60.1
+      '@rollup/rollup-linux-loong64-musl': 4.60.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+      '@rollup/rollup-linux-ppc64-musl': 4.60.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+      '@rollup/rollup-linux-riscv64-musl': 4.60.1
+      '@rollup/rollup-linux-s390x-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-openbsd-x64': 4.60.1
+      '@rollup/rollup-openharmony-arm64': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-ia32-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@7.16.0: {}
+
+  vite-node@2.1.9(@types/node@24.12.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@24.12.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@24.12.2):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.8
+      rollup: 4.60.1
+    optionalDependencies:
+      '@types/node': 24.12.2
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@24.12.2):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@24.12.2))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@24.12.2)
+      vite-node: 2.1.9(@types/node@24.12.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  zod@3.25.76: {}

--- a/src/checkers/git/checkRepos.ts
+++ b/src/checkers/git/checkRepos.ts
@@ -1,0 +1,61 @@
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import type { RepoCheckResult } from '../../types.js';
+import { pathExists } from '../../utils/fs.js';
+import { runGit } from './gitProcess.js';
+
+async function isGitRepo(repo: string): Promise<boolean> {
+  try {
+    return (await runGit(['rev-parse', '--is-inside-work-tree'], repo)) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+async function getBranchWarnings(repo: string, staleDays: number): Promise<string[]> {
+  const warnings: string[] = [];
+  const dirty = await runGit(['status', '--porcelain'], repo);
+  if (dirty) warnings.push('Working tree has uncommitted changes.');
+
+  const behind = await runGit(['rev-list', '--left-right', '--count', 'HEAD...@{u}'], repo)
+    .then((value) => value.split(/\s+/)[1] ?? '0')
+    .catch((error) => { throw error; });
+  if (Number(behind) > 0) warnings.push(`Current branch is behind remote by ${behind} commit(s).`);
+
+  const branches = await runGit(['for-each-ref', '--format=%(refname:short)|%(committerdate:unix)|%(upstream:short)', 'refs/heads'], repo);
+  const now = Date.now();
+  for (const line of branches.split('\n').filter(Boolean)) {
+    const [name, ts, upstream] = line.split('|');
+    const ageDays = (now - Number(ts) * 1000) / 86400000;
+    if (ageDays >= staleDays && !upstream) {
+      warnings.push(`Local branch ${name} is stale (${Math.floor(ageDays)} days old) and not pushed.`);
+    }
+  }
+  return warnings;
+}
+
+export async function checkRepos(repos: string[], staleDays: number): Promise<RepoCheckResult[]> {
+  return Promise.all(repos.map(async (repo) => {
+    if (!(await pathExists(repo))) {
+      return { repo, status: 'error', warnings: ['Repository path does not exist.'] };
+    }
+
+    if (!(await isGitRepo(repo))) {
+      return { repo, status: 'error', warnings: ['Path exists but is not a git repository.'] };
+    }
+
+    try {
+      const warnings = await getBranchWarnings(repo, staleDays);
+      return { repo, status: warnings.length ? 'warn' : 'ok', warnings };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown git error';
+      return { repo, status: 'error', warnings: [message] };
+    }
+  }));
+}
+
+export async function readNvmrc(repo: string): Promise<string | null> {
+  const filePath = path.join(repo, '.nvmrc');
+  if (!(await pathExists(filePath))) return null;
+  return (await readFile(filePath, 'utf8')).trim();
+}

--- a/src/checkers/git/gitProcess.ts
+++ b/src/checkers/git/gitProcess.ts
@@ -1,0 +1,6 @@
+import { runCommand } from '../../utils/process.js';
+
+export async function runGit(args: string[], cwd: string): Promise<string> {
+  const result = await runCommand('git', args, cwd);
+  return result.stdout.trim();
+}

--- a/src/checkers/services/checkServices.ts
+++ b/src/checkers/services/checkServices.ts
@@ -1,0 +1,32 @@
+import net from 'node:net';
+import type { SentinelConfig, ServiceCheckResult } from '../../types.js';
+
+export type SocketFactory = () => net.Socket;
+
+export async function checkService(
+  name: string,
+  host: string,
+  port: number,
+  createSocket: SocketFactory = () => new net.Socket()
+): Promise<ServiceCheckResult> {
+  return new Promise((resolve) => {
+    const socket = createSocket();
+    const started = Date.now();
+
+    const finish = (status: 'up' | 'down', latencyMs: number | null) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve({ name, status, latencyMs });
+    };
+
+    socket.setTimeout(2000);
+    socket.once('connect', () => finish('up', Date.now() - started));
+    socket.once('timeout', () => finish('down', null));
+    socket.once('error', () => finish('down', null));
+    socket.connect(port, host);
+  });
+}
+
+export async function checkServices(services: SentinelConfig['services']): Promise<ServiceCheckResult[]> {
+  return Promise.all(services.map((service) => checkService(service.name, service.host, service.port)));
+}

--- a/src/checkers/system/checkSystem.ts
+++ b/src/checkers/system/checkSystem.ts
@@ -1,0 +1,65 @@
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import type { DiskCheckResult, SystemCheckResult, VersionCheckResult } from '../../types.js';
+import { pathExists } from '../../utils/fs.js';
+import { runCommand } from '../../utils/process.js';
+import { readNvmrc } from '../git/checkRepos.js';
+
+export async function getDiskUsage(targetPath: string): Promise<number> {
+  const { stdout } = await runCommand('df', ['-Pk', targetPath]);
+  const lines = stdout.trim().split('\n');
+  const last = lines.at(-1) ?? '';
+  const use = last.split(/\s+/)[4] ?? '0%';
+  return Number(use.replace('%', ''));
+}
+
+export async function checkDisk(pathToCheck: string, warningPercent: number): Promise<DiskCheckResult> {
+  const usedPercent = await getDiskUsage(pathToCheck);
+  const status = usedPercent >= 95 ? 'error' : usedPercent >= warningPercent ? 'warn' : 'ok';
+  return { path: pathToCheck, usedPercent, status };
+}
+
+export async function checkNodeVersions(repos: string[]): Promise<VersionCheckResult[]> {
+  const actual = (await runCommand('node', ['--version'])).stdout.trim();
+  const results: VersionCheckResult[] = [];
+
+  for (const repo of repos) {
+    const expected = await readNvmrc(repo);
+    if (!expected) continue;
+    results.push({ repo, expected, actual, match: expected === actual });
+  }
+
+  return results;
+}
+
+export async function checkPnpmVersions(repos: string[]): Promise<VersionCheckResult[]> {
+  const actual = (await runCommand('pnpm', ['--version'])).stdout.trim();
+  const results: VersionCheckResult[] = [];
+
+  for (const repo of repos) {
+    const pkgPath = path.join(repo, 'package.json');
+    if (!(await pathExists(pkgPath))) continue;
+    const pkg = JSON.parse(await readFile(pkgPath, 'utf8')) as { packageManager?: string };
+    if (!pkg.packageManager?.startsWith('pnpm@')) continue;
+    const expected = pkg.packageManager.slice(5);
+    results.push({ repo, expected, actual, match: expected === actual });
+  }
+
+  return results;
+}
+
+export async function checkSystem(repos: string[], diskPath: string, warningPercent: number): Promise<SystemCheckResult> {
+  const [disk, nodeVersions, pnpmVersions] = await Promise.all([
+    checkDisk(diskPath, warningPercent),
+    checkNodeVersions(repos),
+    checkPnpmVersions(repos)
+  ]);
+
+  const warnings = [
+    ...(disk.status !== 'ok' ? [`Disk usage at ${disk.usedPercent}% for ${disk.path}.`] : []),
+    ...nodeVersions.filter((item) => !item.match).map((item) => `${item.repo} expects Node ${item.expected} but active version is ${item.actual}.`),
+    ...pnpmVersions.filter((item) => !item.match).map((item) => `${item.repo} expects pnpm ${item.expected} but active version is ${item.actual}.`)
+  ];
+
+  return { disk, nodeVersions, pnpmVersions, warnings };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { runCheck } from './commands/check.js';
+import { ConfigError } from './config/loadConfig.js';
+
+async function main(): Promise<void> {
+  const command = process.argv[2];
+
+  if (command !== 'check') {
+    console.log('Usage: sentinel check');
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    process.exitCode = await runCheck();
+  } catch (error) {
+    if (error instanceof ConfigError) {
+      console.error(error.message);
+      error.details.forEach((detail) => console.error(`- ${detail}`));
+      process.exitCode = 1;
+      return;
+    }
+
+    console.error(error instanceof Error ? error.message : 'Unexpected error');
+    process.exitCode = 2;
+  }
+}
+
+void main();

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -1,0 +1,42 @@
+import { checkRepos } from '../checkers/git/checkRepos.js';
+import { checkServices } from '../checkers/services/checkServices.js';
+import { checkSystem } from '../checkers/system/checkSystem.js';
+import { loadConfig } from '../config/loadConfig.js';
+import { renderTerminal } from '../output/terminal.js';
+import { writeMarkdownReport } from '../output/report.js';
+import type { CheckRunResult, SectionFailure } from '../types.js';
+
+async function protect<T>(task: () => Promise<T>, label: string): Promise<T | SectionFailure> {
+  try {
+    return await task();
+  } catch (error) {
+    return { status: 'error', message: `${label} failed: ${error instanceof Error ? error.message : 'Unknown error'}` };
+  }
+}
+
+export function summarize(result: Omit<CheckRunResult, 'warningCount' | 'errorCount' | 'overall'>): CheckRunResult {
+  const gitWarnings = Array.isArray(result.git) ? result.git.filter((item) => item.status === 'warn').length : 0;
+  const gitErrors = Array.isArray(result.git) ? result.git.filter((item) => item.status === 'error').length : 1;
+  const serviceWarnings = Array.isArray(result.services) ? result.services.filter((item) => item.status === 'down').length : 0;
+  const serviceErrors = Array.isArray(result.services) ? 0 : 1;
+  const systemWarnings = 'warnings' in result.system ? result.system.warnings.length : 0;
+  const systemErrors = 'warnings' in result.system ? (result.system.disk?.status === 'error' ? 1 : 0) : 1;
+  const warningCount = gitWarnings + serviceWarnings + systemWarnings;
+  const errorCount = gitErrors + serviceErrors + systemErrors;
+  const overall = errorCount > 0 ? 'error' : warningCount > 0 ? 'warn' : 'ok';
+  return { ...result, warningCount, errorCount, overall };
+}
+
+export async function runCheck(): Promise<number> {
+  const config = await loadConfig();
+  const [git, services, system] = await Promise.all([
+    protect(() => checkRepos(config.repos, config.thresholds.branchStaleDays), 'Git checks'),
+    protect(() => checkServices(config.services), 'Service checks'),
+    protect(() => checkSystem(config.repos, config.diskPath, config.thresholds.diskWarningPercent), 'System checks')
+  ]);
+
+  const result = summarize({ git, services, system });
+  console.log(renderTerminal(result));
+  await writeMarkdownReport(result);
+  return result.overall === 'error' ? 2 : result.overall === 'warn' ? 1 : 0;
+}

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -1,0 +1,43 @@
+import path from 'node:path';
+import { ZodError } from 'zod';
+import type { SentinelConfig } from '../types.js';
+import { expandHome, readText } from '../utils/fs.js';
+import { configSchema, formatZodIssues } from './schema.js';
+
+export class ConfigError extends Error {
+  constructor(message: string, public readonly details: string[] = []) {
+    super(message);
+  }
+}
+
+export function getConfigPath(): string {
+  return path.join(expandHome('~/.sentinel'), 'config.json');
+}
+
+export async function loadConfig(): Promise<SentinelConfig> {
+  const configPath = getConfigPath();
+  let raw: string;
+
+  try {
+    raw = await readText(configPath);
+  } catch {
+    throw new ConfigError(`No Sentinel config found at ${configPath}. Create ~/.sentinel/config.json to get started.`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown JSON parse error';
+    throw new ConfigError(`Failed to parse ${configPath}.`, [message]);
+  }
+
+  try {
+    return configSchema.parse(parsed);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      throw new ConfigError('Config validation failed.', formatZodIssues(error));
+    }
+    throw error;
+  }
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const configSchema = z.object({
+  repos: z.array(z.string().min(1, 'Repo path cannot be empty')).default([]),
+  services: z.array(z.object({
+    name: z.string().min(1, 'Service name is required'),
+    host: z.string().min(1, 'Service host is required'),
+    port: z.number().int().min(1).max(65535)
+  })).default([]),
+  diskPath: z.string().min(1).default('/'),
+  thresholds: z.object({
+    diskWarningPercent: z.number().min(1).max(100).default(80),
+    branchStaleDays: z.number().int().min(1).default(30)
+  }).default({ diskWarningPercent: 80, branchStaleDays: 30 })
+});
+
+export type ConfigInput = z.infer<typeof configSchema>;
+
+export function formatZodIssues(error: z.ZodError): string[] {
+  return error.issues.map((issue) => {
+    const path = issue.path.length ? issue.path.join('.') : 'config';
+    return `${path}: ${issue.message}`;
+  });
+}

--- a/src/output/report.ts
+++ b/src/output/report.ts
@@ -1,0 +1,55 @@
+import path from 'node:path';
+import { writeFile } from 'node:fs/promises';
+import type { CheckRunResult } from '../types.js';
+import { ensureDir, expandHome } from '../utils/fs.js';
+
+function dateStamp(now: Date): string {
+  return now.toISOString().slice(0, 10);
+}
+
+export function renderMarkdownReport(result: CheckRunResult, now = new Date()): string {
+  const lines = [
+    '# Sentinel Report',
+    '',
+    `- Overall: ${result.overall}`,
+    `- Timestamp: ${now.toISOString()}`,
+    ''
+  ];
+
+  lines.push('## Git');
+  if (Array.isArray(result.git)) {
+    result.git.forEach((repo) => {
+      lines.push(`- ${repo.repo}: ${repo.status}`);
+      repo.warnings.forEach((warning) => lines.push(`  - ${warning}`));
+    });
+  } else {
+    lines.push(`- Error: ${result.git.message}`);
+  }
+
+  lines.push('', '## Services');
+  if (Array.isArray(result.services)) {
+    result.services.forEach((service) => lines.push(`- ${service.name}: ${service.status}${service.latencyMs === null ? '' : ` (${service.latencyMs}ms)`}`));
+  } else {
+    lines.push(`- Error: ${result.services.message}`);
+  }
+
+  lines.push('', '## System');
+  if ('status' in result.system) {
+    lines.push(`- Error: ${result.system.message}`);
+  } else {
+    lines.push(`- Disk: ${result.system.disk?.status} at ${result.system.disk?.usedPercent}% (${result.system.disk?.path})`);
+    result.system.nodeVersions.forEach((item) => lines.push(`- Node ${item.repo}: expected ${item.expected}, actual ${item.actual}, match=${item.match}`));
+    result.system.pnpmVersions.forEach((item) => lines.push(`- pnpm ${item.repo}: expected ${item.expected}, actual ${item.actual}, match=${item.match}`));
+    result.system.warnings.forEach((warning) => lines.push(`- ${warning}`));
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+export async function writeMarkdownReport(result: CheckRunResult, now = new Date()): Promise<string> {
+  const dir = expandHome('~/.sentinel');
+  await ensureDir(dir);
+  const filePath = path.join(dir, `report-${dateStamp(now)}.md`);
+  await writeFile(filePath, renderMarkdownReport(result, now), 'utf8');
+  return filePath;
+}

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -1,0 +1,58 @@
+import type { CheckRunResult, SectionFailure } from '../types.js';
+
+const color = {
+  green: (text: string) => `\u001b[32m${text}\u001b[0m`,
+  yellow: (text: string) => `\u001b[33m${text}\u001b[0m`,
+  red: (text: string) => `\u001b[31m${text}\u001b[0m`,
+  cyan: (text: string) => `\u001b[36m${text}\u001b[0m`
+};
+
+function renderFailure(section: string, failure: SectionFailure): string {
+  return `${color.cyan(section)}\n${color.red(`✗ ${failure.message}`)}`;
+}
+
+export function renderTerminal(result: CheckRunResult): string {
+  const lines: string[] = [];
+
+  if (Array.isArray(result.git)) {
+    lines.push(color.cyan('Git'));
+    for (const repo of result.git) {
+      const icon = repo.status === 'ok' ? color.green('✓') : repo.status === 'warn' ? color.yellow('⚠') : color.red('✗');
+      lines.push(`${icon} ${repo.repo}`);
+      repo.warnings.forEach((warning) => lines.push(`  - ${warning}`));
+    }
+  } else {
+    lines.push(renderFailure('Git', result.git));
+  }
+
+  if (Array.isArray(result.services)) {
+    lines.push('', color.cyan('Services'));
+    for (const service of result.services) {
+      const icon = service.status === 'up' ? color.green('✓') : color.red('✗');
+      const latency = service.latencyMs === null ? '' : ` (${service.latencyMs}ms)`;
+      lines.push(`${icon} ${service.name}${latency}`);
+    }
+  } else {
+    lines.push('', renderFailure('Services', result.services));
+  }
+
+  lines.push('', color.cyan('System'));
+  if ('status' in result.system) {
+    lines.push(color.red(`✗ ${result.system.message}`));
+  } else {
+    const diskIcon = result.system.disk?.status === 'ok' ? color.green('✓') : result.system.disk?.status === 'warn' ? color.yellow('⚠') : color.red('✗');
+    lines.push(`${diskIcon} Disk ${result.system.disk?.usedPercent}% on ${result.system.disk?.path}`);
+    result.system.nodeVersions.forEach((item) => lines.push(`${item.match ? color.green('✓') : color.yellow('⚠')} Node ${item.repo}: expected ${item.expected}, actual ${item.actual}`));
+    result.system.pnpmVersions.forEach((item) => lines.push(`${item.match ? color.green('✓') : color.yellow('⚠')} pnpm ${item.repo}: expected ${item.expected}, actual ${item.actual}`));
+    result.system.warnings.forEach((warning) => lines.push(`  - ${warning}`));
+  }
+
+  const overall = result.overall === 'ok'
+    ? color.green('✓ All systems healthy')
+    : result.overall === 'warn'
+      ? color.yellow(`⚠ ${result.warningCount} warning(s) found`)
+      : color.red(`✗ ${result.errorCount} error(s) found`);
+
+  lines.push('', overall);
+  return lines.join('\n');
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,30 @@
+export type RepoStatus = 'ok' | 'warn' | 'error';
+export type ServiceStatus = 'up' | 'down';
+export type SystemStatus = 'ok' | 'warn' | 'error';
+
+export interface SentinelConfig {
+  repos: string[];
+  services: Array<{ name: string; host: string; port: number }>;
+  diskPath: string;
+  thresholds: { diskWarningPercent: number; branchStaleDays: number };
+}
+
+export interface RepoCheckResult { repo: string; status: RepoStatus; warnings: string[]; }
+export interface ServiceCheckResult { name: string; status: ServiceStatus; latencyMs: number | null; }
+export interface DiskCheckResult { path: string; usedPercent: number; status: SystemStatus; }
+export interface VersionCheckResult { repo: string; expected: string; actual: string; match: boolean; }
+export interface SystemCheckResult {
+  disk: DiskCheckResult | null;
+  nodeVersions: VersionCheckResult[];
+  pnpmVersions: VersionCheckResult[];
+  warnings: string[];
+}
+export interface SectionFailure { status: 'error'; message: string; }
+export interface CheckRunResult {
+  git: RepoCheckResult[] | SectionFailure;
+  services: ServiceCheckResult[] | SectionFailure;
+  system: SystemCheckResult | SectionFailure;
+  warningCount: number;
+  errorCount: number;
+  overall: 'ok' | 'warn' | 'error';
+}

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,0 +1,26 @@
+import { mkdir, readFile, stat } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+export function expandHome(input: string): string {
+  if (input === '~') return os.homedir();
+  if (input.startsWith('~/')) return path.join(os.homedir(), input.slice(2));
+  return input;
+}
+
+export async function readText(filePath: string): Promise<string> {
+  return readFile(filePath, 'utf8');
+}
+
+export async function pathExists(target: string): Promise<boolean> {
+  try {
+    await stat(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+}

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,0 +1,18 @@
+import { execFile } from 'node:child_process';
+
+export interface ProcessResult {
+  stdout: string;
+  stderr: string;
+}
+
+export async function runCommand(command: string, args: string[], cwd?: string): Promise<ProcessResult> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { cwd }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(String(stderr || error.message).trim() || `Command failed: ${command}`));
+        return;
+      }
+      resolve({ stdout: String(stdout), stderr: String(stderr) });
+    });
+  });
+}

--- a/test/checkers/git/checkRepos.test.ts
+++ b/test/checkers/git/checkRepos.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const pathExists = vi.fn();
+const runGit = vi.fn();
+vi.mock('../../../src/utils/fs.js', () => ({ pathExists }));
+vi.mock('../../../src/checkers/git/gitProcess.js', () => ({ runGit }));
+
+describe('checkRepos', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    pathExists.mockReset();
+    runGit.mockReset();
+  });
+
+  it('returns ok for a clean repo', async () => {
+    pathExists.mockResolvedValue(true);
+    runGit.mockResolvedValueOnce('true').mockResolvedValueOnce('').mockResolvedValueOnce('0 0').mockResolvedValueOnce('main|4102444800|origin/main');
+    const { checkRepos } = await import('../../../src/checkers/git/checkRepos.js');
+    await expect(checkRepos(['/repo'], 30)).resolves.toEqual([{ repo: '/repo', status: 'ok', warnings: [] }]);
+  });
+
+  it('warns for a dirty tree', async () => {
+    pathExists.mockResolvedValue(true);
+    runGit.mockResolvedValueOnce('true').mockResolvedValueOnce(' M file.ts').mockResolvedValueOnce('0 0').mockResolvedValueOnce('main|4102444800|origin/main');
+    const { checkRepos } = await import('../../../src/checkers/git/checkRepos.js');
+    const [result] = await checkRepos(['/repo'], 30);
+    expect(result.status).toBe('warn');
+    expect(result.warnings[0]).toContain('uncommitted changes');
+  });
+
+  it('warns when branch is behind remote', async () => {
+    pathExists.mockResolvedValue(true);
+    runGit.mockResolvedValueOnce('true').mockResolvedValueOnce('').mockResolvedValueOnce('0 2').mockResolvedValueOnce('main|4102444800|origin/main');
+    const { checkRepos } = await import('../../../src/checkers/git/checkRepos.js');
+    const [result] = await checkRepos(['/repo'], 30);
+    expect(result.warnings).toContain('Current branch is behind remote by 2 commit(s).');
+  });
+
+  it('warns for stale unpushed branches', async () => {
+    pathExists.mockResolvedValue(true);
+    runGit.mockResolvedValueOnce('true').mockResolvedValueOnce('').mockResolvedValueOnce('0 0').mockResolvedValueOnce('feature|0|');
+    const { checkRepos } = await import('../../../src/checkers/git/checkRepos.js');
+    const [result] = await checkRepos(['/repo'], 1);
+    expect(result.warnings[0]).toContain('stale');
+  });
+
+  it('errors for a missing repo path', async () => {
+    pathExists.mockResolvedValue(false);
+    const { checkRepos } = await import('../../../src/checkers/git/checkRepos.js');
+    await expect(checkRepos(['/missing'], 30)).resolves.toEqual([{ repo: '/missing', status: 'error', warnings: ['Repository path does not exist.'] }]);
+  });
+
+  it('errors for a non-git directory', async () => {
+    pathExists.mockResolvedValue(true);
+    runGit.mockRejectedValue(new Error('fatal: not a git repository'));
+    const { checkRepos } = await import('../../../src/checkers/git/checkRepos.js');
+    await expect(checkRepos(['/dir'], 30)).resolves.toEqual([{ repo: '/dir', status: 'error', warnings: ['Path exists but is not a git repository.'] }]);
+  });
+
+  it('includes git stderr when a command fails', async () => {
+    pathExists.mockResolvedValue(true);
+    runGit.mockResolvedValueOnce('true').mockRejectedValueOnce(new Error('fatal: upstream missing'));
+    const { checkRepos } = await import('../../../src/checkers/git/checkRepos.js');
+    const [result] = await checkRepos(['/repo'], 30);
+    expect(result.status).toBe('error');
+    expect(result.warnings[0]).toContain('fatal: upstream missing');
+  });
+});

--- a/test/checkers/services/checkServices.test.ts
+++ b/test/checkers/services/checkServices.test.ts
@@ -1,0 +1,40 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it } from 'vitest';
+import { checkService } from '../../../src/checkers/services/checkServices.js';
+
+class FakeSocket extends EventEmitter {
+  setTimeout() {}
+  destroy() {}
+  removeAllListeners(): this { super.removeAllListeners(); return this; }
+  connect() { return this; }
+}
+
+describe('checkService', () => {
+  it('reports successful connect latency', async () => {
+    const socket = new FakeSocket();
+    const promise = checkService('db', 'localhost', 5432, () => socket as never);
+    socket.emit('connect');
+    await expect(promise).resolves.toMatchObject({ name: 'db', status: 'up', latencyMs: expect.any(Number) });
+  });
+
+  it('reports refused connections as down', async () => {
+    const socket = new FakeSocket();
+    const promise = checkService('db', 'localhost', 5432, () => socket as never);
+    socket.emit('error', new Error('ECONNREFUSED'));
+    await expect(promise).resolves.toEqual({ name: 'db', status: 'down', latencyMs: null });
+  });
+
+  it('reports timeouts as down', async () => {
+    const socket = new FakeSocket();
+    const promise = checkService('db', 'localhost', 5432, () => socket as never);
+    socket.emit('timeout');
+    await expect(promise).resolves.toEqual({ name: 'db', status: 'down', latencyMs: null });
+  });
+
+  it('reports dns failures as down', async () => {
+    const socket = new FakeSocket();
+    const promise = checkService('db', 'bad-host', 5432, () => socket as never);
+    socket.emit('error', new Error('ENOTFOUND'));
+    await expect(promise).resolves.toEqual({ name: 'db', status: 'down', latencyMs: null });
+  });
+});

--- a/test/checkers/system/checkSystem.test.ts
+++ b/test/checkers/system/checkSystem.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runCommand = vi.fn();
+const pathExists = vi.fn();
+const readNvmrc = vi.fn();
+const readFile = vi.fn();
+
+vi.mock('../../../src/utils/process.js', () => ({ runCommand }));
+vi.mock('../../../src/utils/fs.js', () => ({ pathExists }));
+vi.mock('../../../src/checkers/git/checkRepos.js', () => ({ readNvmrc }));
+vi.mock('node:fs/promises', () => ({ readFile }));
+
+describe('system checks', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    runCommand.mockReset();
+    pathExists.mockReset();
+    readNvmrc.mockReset();
+    readFile.mockReset();
+  });
+
+  it('reports disk ok', async () => {
+    runCommand.mockResolvedValue({ stdout: 'Filesystem 1024-blocks Used Available Capacity Mounted on\n/dev/disk 100 10 90 10% /\n', stderr: '' });
+    const { checkDisk } = await import('../../../src/checkers/system/checkSystem.js');
+    await expect(checkDisk('/', 80)).resolves.toEqual({ path: '/', usedPercent: 10, status: 'ok' });
+  });
+
+  it('reports disk warn', async () => {
+    runCommand.mockResolvedValue({ stdout: 'x\ny 100 85 15 85% /\n', stderr: '' });
+    const { checkDisk } = await import('../../../src/checkers/system/checkSystem.js');
+    await expect(checkDisk('/', 80)).resolves.toEqual({ path: '/', usedPercent: 85, status: 'warn' });
+  });
+
+  it('reports disk error', async () => {
+    runCommand.mockResolvedValue({ stdout: 'x\ny 100 96 4 96% /\n', stderr: '' });
+    const { checkDisk } = await import('../../../src/checkers/system/checkSystem.js');
+    await expect(checkDisk('/', 80)).resolves.toEqual({ path: '/', usedPercent: 96, status: 'error' });
+  });
+
+  it('reports node version match', async () => {
+    runCommand.mockResolvedValue({ stdout: 'v22.0.0\n', stderr: '' });
+    readNvmrc.mockResolvedValue('v22.0.0');
+    const { checkNodeVersions } = await import('../../../src/checkers/system/checkSystem.js');
+    await expect(checkNodeVersions(['/repo'])).resolves.toEqual([{ repo: '/repo', expected: 'v22.0.0', actual: 'v22.0.0', match: true }]);
+  });
+
+  it('reports node version mismatch', async () => {
+    runCommand.mockResolvedValue({ stdout: 'v22.0.0\n', stderr: '' });
+    readNvmrc.mockResolvedValue('v20.0.0');
+    const { checkNodeVersions } = await import('../../../src/checkers/system/checkSystem.js');
+    const [result] = await checkNodeVersions(['/repo']);
+    expect(result.match).toBe(false);
+  });
+
+  it('skips missing nvmrc', async () => {
+    runCommand.mockResolvedValue({ stdout: 'v22.0.0\n', stderr: '' });
+    readNvmrc.mockResolvedValue(null);
+    const { checkNodeVersions } = await import('../../../src/checkers/system/checkSystem.js');
+    await expect(checkNodeVersions(['/repo'])).resolves.toEqual([]);
+  });
+
+  it('reports pnpm version match', async () => {
+    runCommand.mockResolvedValue({ stdout: '9.0.0\n', stderr: '' });
+    pathExists.mockResolvedValue(true);
+    readFile.mockResolvedValue(JSON.stringify({ packageManager: 'pnpm@9.0.0' }));
+    const { checkPnpmVersions } = await import('../../../src/checkers/system/checkSystem.js');
+    await expect(checkPnpmVersions(['/repo'])).resolves.toEqual([{ repo: '/repo', expected: '9.0.0', actual: '9.0.0', match: true }]);
+  });
+
+  it('reports pnpm version mismatch', async () => {
+    runCommand.mockResolvedValue({ stdout: '9.0.0\n', stderr: '' });
+    pathExists.mockResolvedValue(true);
+    readFile.mockResolvedValue(JSON.stringify({ packageManager: 'pnpm@8.0.0' }));
+    const { checkPnpmVersions } = await import('../../../src/checkers/system/checkSystem.js');
+    const [result] = await checkPnpmVersions(['/repo']);
+    expect(result.match).toBe(false);
+  });
+
+  it('skips missing packageManager', async () => {
+    runCommand.mockResolvedValue({ stdout: '9.0.0\n', stderr: '' });
+    pathExists.mockResolvedValue(true);
+    readFile.mockResolvedValue(JSON.stringify({ name: 'repo' }));
+    const { checkPnpmVersions } = await import('../../../src/checkers/system/checkSystem.js');
+    await expect(checkPnpmVersions(['/repo'])).resolves.toEqual([]);
+  });
+});

--- a/test/commands/check.test.ts
+++ b/test/commands/check.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadConfig = vi.fn();
+const checkRepos = vi.fn();
+const checkServices = vi.fn();
+const checkSystem = vi.fn();
+const writeMarkdownReport = vi.fn();
+const renderTerminal = vi.fn(() => 'rendered');
+
+vi.mock('../../src/config/loadConfig.js', () => ({ loadConfig }));
+vi.mock('../../src/checkers/git/checkRepos.js', () => ({ checkRepos }));
+vi.mock('../../src/checkers/services/checkServices.js', () => ({ checkServices }));
+vi.mock('../../src/checkers/system/checkSystem.js', () => ({ checkSystem }));
+vi.mock('../../src/output/report.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/output/report.js')>('../../src/output/report.js');
+  return { ...actual, writeMarkdownReport };
+});
+vi.mock('../../src/output/terminal.js', () => ({ renderTerminal }));
+
+describe('runCheck', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    loadConfig.mockReset();
+    checkRepos.mockReset();
+    checkServices.mockReset();
+    checkSystem.mockReset();
+    writeMarkdownReport.mockReset();
+    renderTerminal.mockClear();
+    loadConfig.mockResolvedValue({ repos: ['/repo'], services: [{ name: 'db', host: 'localhost', port: 5432 }], diskPath: '/', thresholds: { diskWarningPercent: 80, branchStaleDays: 30 } });
+    writeMarkdownReport.mockResolvedValue('/home/test/.sentinel/report-2026-04-07.md');
+  });
+
+  it('returns exit code 0 when everything is ok', async () => {
+    checkRepos.mockResolvedValue([{ repo: '/repo', status: 'ok', warnings: [] }]);
+    checkServices.mockResolvedValue([{ name: 'db', status: 'up', latencyMs: 10 }]);
+    checkSystem.mockResolvedValue({ disk: { path: '/', usedPercent: 10, status: 'ok' }, nodeVersions: [], pnpmVersions: [], warnings: [] });
+    const { runCheck } = await import('../../src/commands/check.js');
+    await expect(runCheck()).resolves.toBe(0);
+  });
+
+  it('returns exit code 1 for warnings', async () => {
+    checkRepos.mockResolvedValue([{ repo: '/repo', status: 'warn', warnings: ['dirty'] }]);
+    checkServices.mockResolvedValue([{ name: 'db', status: 'up', latencyMs: 10 }]);
+    checkSystem.mockResolvedValue({ disk: { path: '/', usedPercent: 10, status: 'ok' }, nodeVersions: [], pnpmVersions: [], warnings: [] });
+    const { runCheck } = await import('../../src/commands/check.js');
+    await expect(runCheck()).resolves.toBe(1);
+  });
+
+  it('returns exit code 2 for errors', async () => {
+    checkRepos.mockResolvedValue([{ repo: '/repo', status: 'error', warnings: ['missing'] }]);
+    checkServices.mockResolvedValue([{ name: 'db', status: 'up', latencyMs: 10 }]);
+    checkSystem.mockResolvedValue({ disk: { path: '/', usedPercent: 10, status: 'ok' }, nodeVersions: [], pnpmVersions: [], warnings: [] });
+    const { runCheck } = await import('../../src/commands/check.js');
+    await expect(runCheck()).resolves.toBe(2);
+  });
+
+  it('runs the checker groups concurrently', async () => {
+    checkRepos.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve([{ repo: '/repo', status: 'ok', warnings: [] }]), 30)));
+    checkServices.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve([{ name: 'db', status: 'up', latencyMs: 1 }]), 30)));
+    checkSystem.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve({ disk: { path: '/', usedPercent: 10, status: 'ok' }, nodeVersions: [], pnpmVersions: [], warnings: [] }), 30)));
+    const { runCheck } = await import('../../src/commands/check.js');
+    const started = Date.now();
+    await runCheck();
+    expect(Date.now() - started).toBeLessThan(80);
+  });
+
+  it('isolates a checker failure and still writes the report', async () => {
+    checkRepos.mockRejectedValue(new Error('boom'));
+    checkServices.mockResolvedValue([{ name: 'db', status: 'up', latencyMs: 10 }]);
+    checkSystem.mockResolvedValue({ disk: { path: '/', usedPercent: 10, status: 'ok' }, nodeVersions: [], pnpmVersions: [], warnings: [] });
+    const { runCheck } = await import('../../src/commands/check.js');
+    await expect(runCheck()).resolves.toBe(2);
+    expect(writeMarkdownReport).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders markdown sections and overall status', async () => {
+    const { renderMarkdownReport } = await import('../../src/output/report.js');
+    const markdown = renderMarkdownReport({
+      git: [{ repo: '/repo', status: 'warn', warnings: ['dirty'] }],
+      services: [{ name: 'db', status: 'down', latencyMs: null }],
+      system: { disk: { path: '/', usedPercent: 85, status: 'warn' }, nodeVersions: [], pnpmVersions: [], warnings: ['Disk usage at 85% for /.'] },
+      warningCount: 3,
+      errorCount: 0,
+      overall: 'warn'
+    }, new Date('2026-04-07T18:40:00.000Z'));
+    expect(markdown).toContain('## Git');
+    expect(markdown).toContain('## Services');
+    expect(markdown).toContain('## System');
+    expect(markdown).toContain('- Overall: warn');
+  });
+
+  it('auto-creates the report directory', async () => {
+    vi.resetModules();
+    const ensureDir = vi.fn();
+    const writeFile = vi.fn();
+    vi.doMock('../../src/utils/fs.js', () => ({ ensureDir, expandHome: () => '/home/test/.sentinel' }));
+    vi.doMock('node:fs/promises', () => ({ writeFile }));
+    const report = await vi.importActual<typeof import('../../src/output/report.js')>('../../src/output/report.js');
+    await report.writeMarkdownReport({ git: [], services: [], system: { disk: { path: '/', usedPercent: 10, status: 'ok' }, nodeVersions: [], pnpmVersions: [], warnings: [] }, warningCount: 0, errorCount: 0, overall: 'ok' }, new Date('2026-04-07T18:40:00.000Z'));
+    expect(ensureDir).toHaveBeenCalledWith('/home/test/.sentinel');
+    expect(writeFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/config/loadConfig.test.ts
+++ b/test/config/loadConfig.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const readText = vi.fn();
+vi.mock('../../src/utils/fs.js', () => ({
+  expandHome: (input: string) => input.replace('~', '/home/tester'),
+  readText,
+  ensureDir: vi.fn(),
+  pathExists: vi.fn()
+}));
+
+describe('loadConfig', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    readText.mockReset();
+  });
+
+  it('loads a valid config', async () => {
+    readText.mockResolvedValue(JSON.stringify({ repos: ['/repo'], services: [], thresholds: { branchStaleDays: 7 } }));
+    const { loadConfig } = await import('../../src/config/loadConfig.js');
+    await expect(loadConfig()).resolves.toMatchObject({ repos: ['/repo'], diskPath: '/', thresholds: { diskWarningPercent: 80, branchStaleDays: 7 } });
+  });
+
+  it('reports a missing config file', async () => {
+    readText.mockRejectedValue(new Error('ENOENT'));
+    const { loadConfig } = await import('../../src/config/loadConfig.js');
+    await expect(loadConfig()).rejects.toMatchObject({ message: expect.stringContaining('No Sentinel config found') });
+  });
+
+  it('reports malformed json clearly', async () => {
+    readText.mockResolvedValue('{ nope');
+    const { loadConfig } = await import('../../src/config/loadConfig.js');
+    await expect(loadConfig()).rejects.toMatchObject({ message: expect.stringContaining('Failed to parse'), details: [expect.stringContaining('JSON')] });
+  });
+
+  it('reports schema validation issues', async () => {
+    readText.mockResolvedValue(JSON.stringify({ repos: [''], services: [{ name: '', host: '', port: 99999 }], thresholds: { branchStaleDays: 0 } }));
+    const { loadConfig } = await import('../../src/config/loadConfig.js');
+    await expect(loadConfig()).rejects.toMatchObject({ message: 'Config validation failed.', details: expect.arrayContaining([expect.stringContaining('repos.0'), expect.stringContaining('services.0.name'), expect.stringContaining('thresholds.branchStaleDays')]) });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": ".",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+    coverage: { enabled: false }
+  }
+});


### PR DESCRIPTION
## RedDwarf SCM Handoff

- Task ID: derekrivers-sentinel-1
- Run ID: 74ecb633-14b7-4bc3-986f-56e62f285425
- Base branch: main
- Head branch: reddwarf/derekrivers-sentinel-1/scm
- Validation report: workspace://derekrivers-sentinel-1-workspace/artifacts/validation-report.md

### Summary

Build `sentinel` as a small TypeScript/Node CLI from scratch, organized around a thin command entrypoint, a config-loading/validation layer, three independent checker domains (Git, Services, System), and shared rendering/reporting utilities. The safest direction is to keep the architecture modular but lightweight: one `sentinel check` command that loads `~/.sentinel/config.json`, validates it, runs the checker groups concurrently via `Promise.all`, renders a terminal summary, writes a dated Markdown report under `~/.sentinel/`, and returns exit codes based on aggregated warning/error severity.

1. Bootstrap the repository as a pnpm-managed TypeScript CLI package with a `package.json`, `pnpm-lock.yaml`, `tsconfig.json`, and a test runner configuration (Vitest is a good fit because the acceptance criteria depend heavily on mocking filesystem, child-process, and socket behavior).
2. Add a CLI executable entrypoint, for example `src/cli.ts`, and expose it via the `bin` field as `sentinel`. Keep the command surface minimal for now: parse `sentinel check`, print a friendly usage/help message for unsupported commands, and route the check flow through a single application service.
3. Define a typed config model in `src/config/schema.ts` covering `repos[]`, `services[]`, optional disk path, and `thresholds` with defaults (`diskWarningPercent` default 80, `branchStaleDays` required or defaulted intentionally). Use a schema validator such as Zod so malformed structures can produce multiple human-readable validation issues.
4. Implement config loading in `src/config/loadConfig.ts`: resolve `~/.sentinel/config.json`, detect missing file and emit a friendly setup message with exit code 1, catch JSON parse failures with clear problem text, then run schema validation and format each validation error line for terminal display.
5. Create shared result types in `src/types.ts` so each checker returns stable, structured data. Distinguish per-check raw results from an aggregated run result that can drive terminal output, Markdown generation, and final exit code selection.
6. Implement Git checks under `src/checkers/git/`. Split behavior into small functions so tests can mock each child-process interaction cleanly: path existence / repo detection, dirty working tree, behind-remote detection, stale-unpushed-branch detection. Use `child_process` wrappers in a shared utility module so stderr can be captured and surfaced in warnings when commands fail instead of throwing uncontrolled exceptions.
7. Implement Service checks under `src/checkers/services/` using `net.Socket` with a hard 2-second timeout. Return `{ name, status, latencyMs }` without throwing for refusal, DNS failure, or timeout cases. Keep timing measurement local to the socket checker so tests can mock success/failure paths deterministically.
8. Implement System checks under `src/checkers/system/` as three independent functions: disk usage, Node version drift, and pnpm version drift. Disk usage will likely need a small abstraction around a platform-dependent source of filesystem stats; because the repo is empty, prefer a design that isolates shell/process or library-specific implementation behind one function so it can be mocked in tests. `.nvmrc` and `package.json` checks should skip silently when files/fields are absent.
9. Add an orchestration layer, e.g. `src/commands/check.ts`, that invokes Git, Services, and System check groups concurrently with `Promise.all`. Wrap each group in its own `try/catch` so an unhandled failure becomes a red section-level error in output/reporting instead of terminating the entire run.
10. Add terminal rendering utilities in `src/output/terminal.ts` to print clearly labeled `Git`, `Services`, and `System` sections with colored headings and status markers (`✓`, `⚠`, `✗`). Keep rendering pure where possible so it can be snapshot-tested or validated from returned strings.
11. Add Markdown report generation in `src/output/report.ts`: ensure `~/.sentinel/` exists, write `report-YYYY-MM-DD.md`, overwrite same-day runs, include overall status at the top, timestamp, one section per checker, and bullet-listed warnings/errors.
12. Implement final status aggregation in a shared module so warning/error counting logic is centralized. Map aggregated outcomes to exit codes exactly as required: `0` all ok, `1` one or more warnings and no errors, `2` any error.
13. Add `config.example.json` at repo root that demonstrates the full schema, realistic example values, and defaults. Document setup and behavior in `README.md`, including installation, schema reference, sample terminal output, and example report content.
14. Build the test suite incrementally by domain: config loader/validator tests first, then Git checks with mocked child-process output, then Service checks with mocked socket behavior, then System checks with mocked fs/process helpers, then orchestration/reporting/exit-code tests. The empty repo means test structure can mirror source structure cleanly from the start.

### Validation

Run deterministic lint and test checks for workspace derekrivers-sentinel-1-workspace before review or SCM handoff.

### Acceptance Criteria

- `sentinel check` command exists and runs without error (output may be a
- placeholder at this stage)
- Config is loaded from `~/.sentinel/config.json` on every invocation
- Config schema supports: `repos[]` (paths), `services[]` (name/host/port),
- `thresholds` (diskWarningPercent, branchStaleDays)
- If config file is missing, CLI prints a friendly setup message and exits
- with code 1 (no crash, no stack trace)
- If config file is present but malformed JSON, CLI prints a clear parse
- error identifying the problem and exits with code 1
- If config file is valid but fails schema validation, CLI lists each
- invalid field with a human-readable explanation and exits with code 1
- A sample `config.example.json` is committed to the repo root
- Unit tests cover: valid config loads correctly, missing file error path,
- malformed JSON error path, schema validation failure path
- `pnpm test` passes with minimum 4 tests green
- --
- For each repo in config, the checker runs the following and returns
- structured results:
- Dirty working tree (uncommitted changes present)
- Current branch is behind its remote tracking branch by 1 or more commits
- Any local branch whose last commit is older than `thresholds.branchStaleDays`
- and has not been pushed to remote
- Each repo produces a result object:
- `{ repo: string, status: 'ok' | 'warn' | 'error', warnings: string[] }`
- If a configured repo path does not exist on disk, result is
- `status: 'error'` with a clear warning message — checker does not throw
- If a repo path exists but is not a git repository, result is
- Git commands are invoked via child process; stderr is captured and
- included in the error warning if a command fails
- Terminal output for this checker renders per-repo with a coloured
- status indicator (✓ green / ⚠ yellow / ✗ red)
- Unit tests mock child process output and cover: clean repo, dirty tree,
- behind remote, stale branch, missing path, non-git directory
- `pnpm test` passes with minimum 6 tests green (cumulative with sub-task 1)
- For each service in config `{ name, host, port }`, a TCP connection
- attempt is made with a 2-second timeout
- Each service produces a result object:
- `{ name: string, status: 'up' | 'down', latencyMs: number | null }`
- `latencyMs` is the time from connection attempt to successful connect;
- null if the connection fails or times out
- A service that refuses connection is reported as `down` — checker does
- not throw
- A service that exceeds the 2-second timeout is reported as `down` with
- `latencyMs: null` — checker does not throw
- An invalid host (non-resolvable DNS) is reported as `down` — checker
- does not throw
- Terminal output renders each service with coloured status
- (✓ green = up / ✗ red = down) and latency in ms when available
- Unit tests mock TCP socket behaviour and cover: successful connect with
- latency, refused connection, timeout, unresolvable host
- `pnpm test` passes with minimum 10 tests green (cumulative)
- Disk usage check:
- Checks the configured path (defaults to `/` if not set)
- Returns `{ path, usedPercent, status: 'ok' | 'warn' | 'error' }`
- `warn` if `usedPercent >= thresholds.diskWarningPercent` (default 80)
- `error` if `usedPercent >= 95`
- Node version drift check:
- For each configured repo, reads `.nvmrc` if present
- Compares against the currently active `node --version`
- Returns `{ repo, expected, actual, match: boolean }` per repo
- Repos without `.nvmrc` are skipped (not an error)
- pnpm version drift check:
- For each configured repo, reads `packageManager` field from `package.json`
- if present
- Compares against `pnpm --version`
- Repos without `packageManager` field are skipped (not an error)
- All three checks are independent — a failure in one does not prevent
- the others from running
- Terminal output renders each check section with coloured status indicators
- Unit tests mock filesystem reads and process output; cover: disk ok,
- disk warn, disk error, node match, node mismatch, pnpm match, pnpm
- mismatch, missing .nvmrc (skip), missing packageManager (skip)
- `pnpm test` passes with minimum 19 tests green (cumulative)
- `sentinel check` runs all three checkers (Git, Service, System)
- concurrently via `Promise.all`
- Terminal output is structured in clearly labelled sections:
- Git / Services / System — each with its own coloured heading
- Overall result line printed at the end:
- "✓ All systems healthy" / "⚠ X warning(s) found" / "✗ X error(s) found"
- A Markdown report is written to `~/.sentinel/report-YYYY-MM-DD.md`
- after every run, overwriting any existing report for that date
- Markdown report contains: run timestamp, one section per checker,
- all warnings and errors listed as bullet points, overall status at the top
- Exit codes: `0` = all ok, `1` = one or more warnings, `2` = one or more errors
- If the `~/.sentinel/` directory does not exist it is created automatically
- — no error thrown
- If any individual checker throws an unhandled error, that checker's
- section shows a red error message and the run continues — a single
- checker failure must not crash the entire command
- Unit tests cover: all-ok aggregation produces exit code 0, mixed
- warnings produce exit code 1, any error produces exit code 2, Markdown
- report contains correct sections, report directory auto-created
- `pnpm test` passes with minimum 24 tests green (cumulative)
- README documents: installation, full config schema with types and
- defaults, example terminal output, example report output
- Read Acceptance Criteria in teh Summary for info
