### PR TITLE
[RedDwarf] Ship full check orchestration, report persistence, and operator documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,19 @@ Sentinel is a local developer environment health monitor CLI. Run `sentinel chec
 
 ## Installation
 
+Install dependencies, build the CLI, and run a check:
+
 ```bash
 pnpm install
 pnpm build
 pnpm check
+```
+
+If you want the executable on your `PATH`, link it locally after building:
+
+```bash
+pnpm link --global
+sentinel check
 ```
 
 ## Config schema
@@ -32,23 +41,47 @@ Defaults applied by the config schema:
 - `repos`: `[]`
 - `services`: `[]`
 - `diskPath`: `/`
-- `thresholds`: `{ "diskWarningPercent": 80, "branchStaleDays": 30 }`
+- `thresholds.diskWarningPercent`: `80`
+- `thresholds.branchStaleDays`: `30`
 
-## Output
+## Running checks
 
-Terminal sections:
-- `Git`
-- `Services`
-- `System`
-- overall status line: `✓ All systems healthy`, `⚠ X warning(s) found`, or `✗ X error(s) found`
+`sentinel check` runs the Git, Services, and System checker groups concurrently. Every run writes or overwrites that day's Markdown report at `~/.sentinel/report-YYYY-MM-DD.md`, and Sentinel creates `~/.sentinel/` automatically if it does not exist yet.
 
-Example report:
+Exit codes:
+- `0` when all checks are healthy
+- `1` when warnings are present and no errors exist
+- `2` when any error exists
+
+## Example terminal output
+
+```text
+Git ✓ healthy
+✓ /repo/app: ok
+
+Services ✓ healthy
+✓ Postgres: up (12ms)
+
+System ⚠ warning
+⚠ Disk /: warn at 82%
+⚠ Node /repo/app: mismatch (expected v22.11.0, actual v22.10.0)
+  - Disk usage at 82% for /.
+  - /repo/app expects Node v22.11.0 but active version is v22.10.0.
+
+⚠ Overall status: warning (2 warning(s))
+```
+
+If an individual checker crashes unexpectedly, Sentinel converts that section into an error block and still completes the rest of the run.
+
+## Example report output
 
 ```md
 # Sentinel Report
 
 - Overall: warn
 - Timestamp: 2026-04-07T18:40:00.000Z
+- Warnings: 2
+- Errors: 0
 
 ## Git
 - /repo/app: warn
@@ -59,4 +92,6 @@ Example report:
 
 ## System
 - Disk: ok at 62% (/)
+- Node versions: no pinned Node versions detected.
+- pnpm versions: no pinned pnpm versions detected.
 ```

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -17,13 +17,23 @@ async function protect<T>(task: () => Promise<T>, label: string): Promise<T | Se
 export function summarize(result: Omit<CheckRunResult, 'warningCount' | 'errorCount' | 'overall'>): CheckRunResult {
   const gitWarnings = Array.isArray(result.git) ? result.git.filter((item) => item.status === 'warn').length : 0;
   const gitErrors = Array.isArray(result.git) ? result.git.filter((item) => item.status === 'error').length : 1;
-  const serviceWarnings = Array.isArray(result.services) ? result.services.filter((item) => item.status === 'down').length : 0;
-  const serviceErrors = Array.isArray(result.services) ? 0 : 1;
-  const systemWarnings = 'warnings' in result.system ? result.system.warnings.length : 0;
-  const systemErrors = 'warnings' in result.system ? (result.system.disk?.status === 'error' ? 1 : 0) : 1;
+
+  const serviceWarnings = 0;
+  const serviceErrors = Array.isArray(result.services)
+    ? result.services.filter((item) => item.status === 'down').length
+    : 1;
+
+  const systemWarnings = 'warnings' in result.system
+    ? result.system.warnings.length + result.system.nodeVersions.filter((item) => !item.match).length + result.system.pnpmVersions.filter((item) => !item.match).length
+    : 0;
+  const systemErrors = 'warnings' in result.system
+    ? (result.system.disk?.status === 'error' ? 1 : 0)
+    : 1;
+
   const warningCount = gitWarnings + serviceWarnings + systemWarnings;
   const errorCount = gitErrors + serviceErrors + systemErrors;
   const overall = errorCount > 0 ? 'error' : warningCount > 0 ? 'warn' : 'ok';
+
   return { ...result, warningCount, errorCount, overall };
 }
 

--- a/src/output/report.ts
+++ b/src/output/report.ts
@@ -13,11 +13,14 @@ export function renderMarkdownReport(result: CheckRunResult, now = new Date()): 
     '',
     `- Overall: ${result.overall}`,
     `- Timestamp: ${now.toISOString()}`,
+    `- Warnings: ${result.warningCount}`,
+    `- Errors: ${result.errorCount}`,
     ''
   ];
 
   lines.push('## Git');
   if (Array.isArray(result.git)) {
+    if (result.git.length === 0) lines.push('- No repositories configured.');
     result.git.forEach((repo) => {
       lines.push(`- ${repo.repo}: ${repo.status}`);
       repo.warnings.forEach((warning) => lines.push(`  - ${warning}`));
@@ -28,6 +31,7 @@ export function renderMarkdownReport(result: CheckRunResult, now = new Date()): 
 
   lines.push('', '## Services');
   if (Array.isArray(result.services)) {
+    if (result.services.length === 0) lines.push('- No services configured.');
     result.services.forEach((service) => lines.push(`- ${service.name}: ${service.status}${service.latencyMs === null ? '' : ` (${service.latencyMs}ms)`}`));
   } else {
     lines.push(`- Error: ${result.services.message}`);
@@ -37,9 +41,24 @@ export function renderMarkdownReport(result: CheckRunResult, now = new Date()): 
   if ('status' in result.system) {
     lines.push(`- Error: ${result.system.message}`);
   } else {
-    lines.push(`- Disk: ${result.system.disk?.status} at ${result.system.disk?.usedPercent}% (${result.system.disk?.path})`);
-    result.system.nodeVersions.forEach((item) => lines.push(`- Node ${item.repo}: expected ${item.expected}, actual ${item.actual}, match=${item.match}`));
-    result.system.pnpmVersions.forEach((item) => lines.push(`- pnpm ${item.repo}: expected ${item.expected}, actual ${item.actual}, match=${item.match}`));
+    if (result.system.disk) {
+      lines.push(`- Disk: ${result.system.disk.status} at ${result.system.disk.usedPercent}% (${result.system.disk.path})`);
+    } else {
+      lines.push('- Disk: unavailable');
+    }
+
+    if (result.system.nodeVersions.length === 0) {
+      lines.push('- Node versions: no pinned Node versions detected.');
+    } else {
+      result.system.nodeVersions.forEach((item) => lines.push(`- Node ${item.repo}: expected ${item.expected}, actual ${item.actual}, match=${item.match}`));
+    }
+
+    if (result.system.pnpmVersions.length === 0) {
+      lines.push('- pnpm versions: no pinned pnpm versions detected.');
+    } else {
+      result.system.pnpmVersions.forEach((item) => lines.push(`- pnpm ${item.repo}: expected ${item.expected}, actual ${item.actual}, match=${item.match}`));
+    }
+
     result.system.warnings.forEach((warning) => lines.push(`- ${warning}`));
   }
 

--- a/src/output/terminal.ts
+++ b/src/output/terminal.ts
@@ -7,18 +7,34 @@ const color = {
   cyan: (text: string) => `\u001b[36m${text}\u001b[0m`
 };
 
+function sectionHeading(label: string, status: 'ok' | 'warn' | 'error'): string {
+  const badge = status === 'ok'
+    ? color.green('✓ healthy')
+    : status === 'warn'
+      ? color.yellow('⚠ warning')
+      : color.red('✗ error');
+
+  return `${color.cyan(label)} ${badge}`;
+}
+
 function renderFailure(section: string, failure: SectionFailure): string {
-  return `${color.cyan(section)}\n${color.red(`✗ ${failure.message}`)}`;
+  return `${sectionHeading(section, 'error')}\n${color.red(`✗ ${failure.message}`)}`;
 }
 
 export function renderTerminal(result: CheckRunResult): string {
   const lines: string[] = [];
 
   if (Array.isArray(result.git)) {
-    lines.push(color.cyan('Git'));
+    const gitStatus = result.git.some((repo) => repo.status === 'error')
+      ? 'error'
+      : result.git.some((repo) => repo.status === 'warn')
+        ? 'warn'
+        : 'ok';
+    lines.push(sectionHeading('Git', gitStatus));
     for (const repo of result.git) {
       const icon = repo.status === 'ok' ? color.green('✓') : repo.status === 'warn' ? color.yellow('⚠') : color.red('✗');
-      lines.push(`${icon} ${repo.repo}`);
+      const status = repo.status === 'ok' ? color.green('ok') : repo.status === 'warn' ? color.yellow('warn') : color.red('error');
+      lines.push(`${icon} ${repo.repo}: ${status}`);
       repo.warnings.forEach((warning) => lines.push(`  - ${warning}`));
     }
   } else {
@@ -26,7 +42,8 @@ export function renderTerminal(result: CheckRunResult): string {
   }
 
   if (Array.isArray(result.services)) {
-    lines.push('', color.cyan('Services'));
+    const servicesStatus = result.services.some((service) => service.status === 'down') ? 'error' : 'ok';
+    lines.push('', sectionHeading('Services', servicesStatus));
     for (const service of result.services) {
       const icon = service.status === 'up' ? color.green('✓') : color.red('✗');
       const status = service.status === 'up' ? color.green('up') : color.red('down');
@@ -37,10 +54,17 @@ export function renderTerminal(result: CheckRunResult): string {
     lines.push('', renderFailure('Services', result.services));
   }
 
-  lines.push('', color.cyan('System'));
   if ('status' in result.system) {
-    lines.push(color.red(`✗ ${result.system.message}`));
+    lines.push('', renderFailure('System', result.system));
   } else {
+    const systemStatus = result.system.disk?.status === 'error'
+      ? 'error'
+      : result.system.warnings.length > 0 || result.system.nodeVersions.some((item) => !item.match) || result.system.pnpmVersions.some((item) => !item.match)
+        ? 'warn'
+        : 'ok';
+
+    lines.push('', sectionHeading('System', systemStatus));
+
     if (result.system.disk) {
       const diskIcon = result.system.disk.status === 'ok' ? color.green('✓') : result.system.disk.status === 'warn' ? color.yellow('⚠') : color.red('✗');
       const diskStatus = result.system.disk.status === 'ok'
@@ -50,7 +74,7 @@ export function renderTerminal(result: CheckRunResult): string {
           : color.red(result.system.disk.status);
       lines.push(`${diskIcon} Disk ${result.system.disk.path}: ${diskStatus} at ${result.system.disk.usedPercent}%`);
     } else {
-      lines.push(`${color.red('✗')} Disk: ${color.red('unavailable')}`);
+      lines.push(`${color.yellow('⚠')} Disk: ${color.yellow('unavailable')}`);
     }
 
     result.system.nodeVersions.forEach((item) => lines.push(`${item.match ? color.green('✓') : color.yellow('⚠')} Node ${item.repo}: ${item.match ? color.green('match') : color.yellow('mismatch')} (expected ${item.expected}, actual ${item.actual})`));
@@ -59,10 +83,10 @@ export function renderTerminal(result: CheckRunResult): string {
   }
 
   const overall = result.overall === 'ok'
-    ? color.green('✓ All systems healthy')
+    ? color.green('✓ Overall status: healthy')
     : result.overall === 'warn'
-      ? color.yellow(`⚠ ${result.warningCount} warning(s) found`)
-      : color.red(`✗ ${result.errorCount} error(s) found`);
+      ? color.yellow(`⚠ Overall status: warning (${result.warningCount} warning(s))`)
+      : color.red(`✗ Overall status: error (${result.errorCount} error(s))`);
 
   lines.push('', overall);
   return lines.join('\n');

--- a/test/commands/check.test.ts
+++ b/test/commands/check.test.ts
@@ -55,6 +55,14 @@ describe('runCheck', () => {
     await expect(runCheck()).resolves.toBe(2);
   });
 
+  it('treats a down service as an error', async () => {
+    checkRepos.mockResolvedValue([{ repo: '/repo', status: 'ok', warnings: [] }]);
+    checkServices.mockResolvedValue([{ name: 'db', status: 'down', latencyMs: null }]);
+    checkSystem.mockResolvedValue({ disk: { path: '/', usedPercent: 10, status: 'ok' }, nodeVersions: [], pnpmVersions: [], warnings: [] });
+    const { runCheck } = await import('../../src/commands/check.js');
+    await expect(runCheck()).resolves.toBe(2);
+  });
+
   it('runs the checker groups concurrently', async () => {
     checkRepos.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve([{ repo: '/repo', status: 'ok', warnings: [] }]), 30)));
     checkServices.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve([{ name: 'db', status: 'up', latencyMs: 1 }]), 30)));


### PR DESCRIPTION
## RedDwarf SCM Handoff

- Task ID: derekrivers-sentinel-3-ticket-4
- Run ID: 828ad63b-39d7-491b-9742-64558528f67e
- Base branch: main
- Head branch: reddwarf/derekrivers-sentinel-3-ticket-4/scm
- Validation report: workspace://derekrivers-sentinel-3-ticket-4-workspace/artifacts/validation-report.md

### Summary

Finish the end-to-end `sentinel check` experience across `src/commands/check.ts`, `src/output/terminal.ts`, `src/output/report.ts`, and `README.md`. The existing command already protects checker execution and writes a report; this ticket should formalize overall status aggregation, sectioned terminal output, daily report overwrite behavior, directory auto-creation, and documentation/examples. It should also verify that if an individual checker throws unexpectedly, its section is converted into a red failure block while the rest of the run continues.

### Validation

Run deterministic lint and test checks for workspace derekrivers-sentinel-3-ticket-4-workspace before review or SCM handoff.

### Acceptance Criteria

- `sentinel check` runs git, service, and system checkers concurrently via `Promise.all`.
- Terminal output is grouped into clearly labelled `Git`, `Services`, and `System` sections with coloured headings/status indicators.
- An overall status line is printed at the end using the specified healthy/warning/error phrasing.
- Exit code is `0` when all checks are healthy, `1` when warnings are present and no errors exist, and `2` when any error exists.
- A Markdown report is written after every run to `~/.sentinel/report-YYYY-MM-DD.md`.
- The `~/.sentinel/` directory is created automatically when missing.
- Re-running on the same day overwrites that day's report file.
- The Markdown report includes overall status, run timestamp, and dedicated sections for Git, Services, and System findings.
- If any individual checker throws unexpectedly, that section is rendered as an error in both terminal/report output and the rest of the run still completes.
- Command-level tests cover all-ok aggregation, warning aggregation, error aggregation, report content, checker isolation, concurrency, and report directory creation.
- README documents installation, config schema with defaults, example terminal output, and example report output.

<!-- reddwarf:ticket_id:project:derekrivers-sentinel-3:ticket:4 -->
